### PR TITLE
Removing patches that already exist in d.o. project

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,14 +30,6 @@
     },
     "extra": {
         "enable-patching": true,
-        "patches": {
-            "drupal/core": {
-                "2743197 - Provide a workaroud to load additional profiles via settings.php":
-                    "https://www.drupal.org/files/issues/make_inherited_install-1356276-129.patch",
-                "2655104 - List unmet dependencies instead of just failing":
-                    "https://www.drupal.org/files/issues/list-missing-dependencies-2655104-19.patch"
-            }
-        },
         "installer-paths": {
             "build/html/core": [
                 "type:drupal-core"


### PR DESCRIPTION
Small thing: these patches already exist in the d.o. project and get applied from there. Additionally the profile inheritance patch doesn't apply anymore, and the more recent patch in the d.o. project takes care of the issue.

Hi Mike!
