### PR TITLE
Update to lightning 2.0.5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -37,8 +37,7 @@
     "composer/installers": "^1.0",
     "drupal-composer/drupal-scaffold": "^2.0.0",
     "cweagans/composer-patches": "~1.6",
-    "acquia/lightning": "~2.0.0",
-    "drupal/diff": "^1.0",
+    "acquia/lightning": "~2.0.5",
     "drupal/field_group": "^1.0",
     "drupal/paragraphs": "1.x-dev",
     "drupal/restui": "^1.0",
@@ -54,8 +53,6 @@
     "enable-patching": true,
     "patches": {
       "drupal/core": {
-        "1356276 - Allow profiles to provide a base/parent profile and load them in the correct order":
-          "https://www.drupal.org/files/issues/1356276-276-8.2.x.patch",
         "2655104 - List unmet dependencies instead of just failing (Committed to 8.3.x)":
           "https://www.drupal.org/files/issues/2655104-56.patch",
         "2699157 - Plugin Lazy loading can cause usort warning":

--- a/octane.info.yml
+++ b/octane.info.yml
@@ -26,6 +26,7 @@ dependencies:
   - lightning_media_instagram
   - lightning_media_twitter
   # - search
+  - facets
   - search_api_db
   - search_api_solr
   - search_api_page

--- a/octane.info.yml
+++ b/octane.info.yml
@@ -6,21 +6,19 @@ distribution:
   name: Octane
 
 # Base profile
-base profile: lightning
+base profile:
+  name: lightning
+  excluded_dependencies:
+    - lightning_media_video
 
 # Required modules
 dependencies:
   # contrib from Lightning
-  - diff
   - entity_browser_entity_form
   - features
   - features_ui
   - field_group
   - page_manager_ui
-  # Lightning modules
-  - lightning_core
-  - lightning_layout
-  - lightning_media
   ### octane contrib
   # - media entities
   - lightning_media_document
@@ -28,8 +26,6 @@ dependencies:
   - lightning_media_instagram
   - lightning_media_twitter
   # - search
-  - search_api
-  - facets
   - search_api_db
   - search_api_solr
   - search_api_page


### PR DESCRIPTION
Lightning 2.0.5 is more friendly to being used as a base profile. This PR takes advantage of those changes.

I had to remove facets from octane's dependencies because it was causing a fatal during install that I don't think is related to this PR. I added it back in before opening though.