### PR TITLE
Correct drupal/coder version and remove php_codesniffer as direct dep…

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,8 +26,7 @@
     "drupal/console": "~1.0.0",
     "phpmd/phpmd": "~2.1",
     "drupal/admin_toolbar": "^1.18",
-    "drupal/coder": "^2.0",
-    "squizlabs/php_codesniffer": "2.*",
+    "drupal/coder": "^8.2",
     "drupal/devel": "^1.0.0-rc1",
     "drupal/masquerade": "2.0.0-beta1",
     "symfony/css-selector": "~2.8"


### PR DESCRIPTION
1. Not sure why drupal/coder is a snowflake (perhaps because it is an actual library, not a module?) but in my experience it needs to be referenced via the "other" style of versioning. Perhaps both styles now work, but this is how we do it in generator-gadget.

2. php_codesniffer will be automatically pulled in as a dependency of drupal/coder. The only reason to include it here would be to create a more specific version range, or to make it more visible that a developer could change it. Proposing to remove it now to simplify confusion around coding style tools troubleshooting.