### PR TITLE
[WIP] Updated Lightning to 2.2.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,6 +9,10 @@
     {
       "type": "composer",
       "url": "https://packages.drupal.org/8"
+    },
+    {
+      "type": "composer",
+      "url": "https://asset-packagist.org"
     }
   ],
   "require-dev": {
@@ -36,7 +40,9 @@
     "composer/installers": "^1.0",
     "drupal-composer/drupal-scaffold": "^2.0.0",
     "cweagans/composer-patches": "^1.6",
-    "acquia/lightning": "^2.1",
+    "acquia/lightning": "^2.2",
+    "bower-asset/cropper": "^2.3",
+    "bower-asset/dropzone": "^5.1",
     "drupal/field_group": "^1.0",
     "drupal/paragraphs": "^1.2",
     "drupal/restui": "^1.0",
@@ -75,7 +81,15 @@
       ],
       "build/html/drush": [
         "type:drupal-drush"
+      ],
+      "build/html/libraries/{$name}": [
+        "type:bower-asset",
+        "type:npm-asset"
       ]
-    }
+    },
+    "installer-types": [
+      "bower-asset",
+      "npm-asset"
+    ],
   }
 }

--- a/composer.json
+++ b/composer.json
@@ -90,6 +90,6 @@
     "installer-types": [
       "bower-asset",
       "npm-asset"
-    ],
+    ]
   }
 }


### PR DESCRIPTION
Updated Lightning to 2.2.0 and added support for new libraries and installer types.

This updates to Lightning 2.2.0, which version bumps to Drupal 8.4.

This version of Lightning also requires 2 new libraries; because they need to appear in the /libraries directory instead of /vendor, so additional installer-types and a new assist repo needs to be added to composer.json here (since they don't inherit from Lightning's composer.json).