### PR TITLE
Adds drupal-test-traits and sample ExistingSite test.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,8 @@
         "se/selenium-server-standalone": "^2.53",
         "symfony/css-selector": "^3.4.0",
         "symfony/phpunit-bridge": "^3.4.3",
-        "symfony/debug": "^3.4.0"
+        "symfony/debug": "^3.4.0",
+        "weitzman/drupal-test-traits": "~1.0"
     },
     "require": {
         "acquia/lightning": "^4.0@alpha",
@@ -61,6 +62,9 @@
         "harvesthq/chosen": "^1.7",
         "kporras07/composer-symlinks": "^0.1.0@dev",
         "roave/security-advisories": "dev-master"
+    },
+    "autoload-dev": {
+        "psr-4": { "Octane\\Tests\\": "test/src/" }
     },
     "scripts": {
         "drupal-scaffold": "DrupalComposer\\DrupalScaffold\\Plugin::scaffold",

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -5,7 +5,7 @@
  or your current system user. See core/tests/README.md and
  https://www.drupal.org/node/2116263 for details.
 -->
-<phpunit bootstrap="build/html/core/tests/bootstrap.php" colors="true"
+<phpunit bootstrap="vendor/weitzman/drupal-test-traits/src/bootstrap.php" colors="true"
          beStrictAboutTestsThatDoNotTestAnything="true"
          beStrictAboutOutputDuringTests="true"
          beStrictAboutChangesToGlobalState="true">
@@ -34,6 +34,11 @@
     <!-- Example for changing the driver args to mink tests MINK_DRIVER_ARGS value: '["http://127.0.0.1:8510"]' -->
     <!-- Example for changing the driver args to phantomjs tests MINK_DRIVER_ARGS_PHANTOMJS value: '["http://127.0.0.1:8510"]' -->
     <!-- Example for changing the driver args to webdriver tests MINK_DRIVER_ARGS_WEBDRIVER value: '["firefox", null, "http://localhost:4444/wd/hub"]' -->
+
+    <!-- ExistingSite test configurations. -->
+    <env name="DTT_BASE_URL" value="http://web"/>
+    <!-- @todo We need a headless chrome container for JS tests to work out of the box. -->
+    <env name="DTT_API_URL" value="http://headless:9222"/>
   </php>
   <testsuites>
     <testsuite name="unit">
@@ -42,6 +47,7 @@
       <directory>./build/html/sites/*/modules/*/tests/src/Unit</directory>
       <!-- Exclude Core Drupal tests. -->
       <exclude>./build/html/core</exclude>
+      <exclude>./build/html/modules/contrib</exclude>
       <!-- Exclude Composer's vendor directory so we don't run tests there. -->
       <exclude>./vendor</exclude>
       <!-- Exclude pattern lab's vendor directory inside of themes. -->
@@ -53,6 +59,7 @@
       <directory>./build/html/sites/*/modules/*/tests/src/Kernel</directory>
       <!-- Exclude Drupal Kernal tests. -->
       <exclude>./build/html/core</exclude>
+      <exclude>./build/html/modules/contrib</exclude>
       <!-- Exclude pattern lab's vendor directory inside of themes. -->
       <exclude>./*/pattern-lab/vendor</exclude>
     </testsuite>
@@ -62,18 +69,25 @@
       <directory>./build/html/sites/*/modules/*/tests/src/Functional</directory>
       <!-- Exclude Core Drupal Functional tests. -->
       <exclude>./build/html/core</exclude>
+      <exclude>./build/html/modules/contrib</exclude>
       <!-- Exclude pattern lab's vendor directory inside of themes. -->
       <exclude>./*/pattern-lab/vendor</exclude>
     </testsuite>
     <testsuite name="functional-javascript">
       <directory>./build/html/modules/custom/*/tests/src/FunctionalJavascript</directory>
+      <directory>./tests/src/ExistingSite</directory>
       <exclude>./build/html/core</exclude>
       <exclude>./build/html/core/vendor</exclude>
+      <exclude>./build/html/modules/contrib</exclude>
       <!-- Exclude pattern lab's vendor directory inside of themes. -->
       <exclude>./*/pattern-lab/vendor</exclude>
     </testsuite>
     <testsuite name="existing-site">
       <directory>./build/html/modules/custom/*/tests/src/ExistingSite</directory>
+      <directory>./test/src/ExistingSite</directory>
+      <!-- Exclude Core Drupal Functional tests. -->
+      <exclude>./build/html/core</exclude>
+      <exclude>./build/html/modules/contrib</exclude>
       <!-- Exclude pattern lab's vendor directory inside of themes. -->
       <exclude>./src/themes/*/pattern-lab/vendor</exclude>
     </testsuite>

--- a/test/src/ExistingSite/FrontPageTest.php
+++ b/test/src/ExistingSite/FrontPageTest.php
@@ -1,0 +1,100 @@
+<?php
+
+namespace Octane\Tests\ExistingSite;
+
+/**
+ * Demonstrates how to use ExistingSite tests.
+ *
+ * Unlike the other PHPUnit-based test types, ExistingSite tests run against the
+ * fully-configured site. This is similar to Behat, but allows testing things
+ * that Behat was never meant to test.
+ *
+ * Thinks like access, views, content types, and other heavily configuration-
+ * dependent things are ideally suited for this type of test since any enabled
+ * module can potentially alter the expected behavior of these things.
+ *
+ * Additional tests can be placed in this namespace/directory, but typically in
+ * a project they will go into a base module, or a module specifically related
+ * to the test: `src/modules/foo_base/tests/src/ExistingSite`.
+ *
+ * @group octane
+ */
+class FrontPageTest extends OctaneExistingSiteTestBase {
+
+  /**
+   * An authenticated user.
+   *
+   * @var \Drupal\user\UserInterface
+   */
+  protected $normalUser;
+
+  /**
+   * An admin user.
+   *
+   * @var \Drupal\user\UserInterface
+   */
+  protected $adminUser;
+
+  /**
+   * {@inheritdoc}
+   */
+  public function setUp() {
+    parent::setUp();
+
+    // Typically a user is created with no arguments and a role is assigned later.
+    // This differs from the other phpunit test types where roles are unimportant,
+    // but permissions are. Since this is just an authenticated user, no special
+    // permissions or roles are assigned.
+    //
+    // Users (and nodes and terms) created this way are automatically removed
+    // in the `tearDown` method. See the parent classes for more details.
+    //
+    // Additional entity types can be added for cleanup by simply calling:
+    //
+    // @code
+    //   $this->markEntityForCleanup($entity);
+    // @endcode
+    $this->normalUser = $this->createUser();
+
+    // Create an administrator user. This assumes the site has a role called
+    // 'administrator'.
+    $this->adminUser = $this->createUser();
+    $this->adminUser->addRole('administrator');
+    $this->adminUser->save();
+  }
+
+  /**
+   * Tests the front page as an anonymous user.
+   */
+  public function testAnonymous() {
+    $this->visit('/');
+    $this->assertSession()->statusCodeEquals(200);
+  }
+
+  /**
+   * Tests the front page as a normal authenticated user.
+   */
+  public function testAuthenticated() {
+    $this->drupalLogin($this->normalUser);
+    $this->visit('/');
+    $this->assertSession()->statusCodeEquals(200);
+
+    // Admin pages should not be available.
+    $this->visit('/admin');
+    $this->assertSession()->statusCodeEquals(403);
+  }
+
+  /**
+   * Tests the front page as an admin and performs other operations.
+   */
+  public function testAdmin() {
+    $this->drupalLogin($this->adminUser);
+    $this->visit('/');
+    $this->assertSession()->statusCodeEquals(200);
+
+    // Admin pages should be available.
+    $this->visit('/admin');
+    $this->assertSession()->statusCodeEquals(200);
+  }
+
+}

--- a/test/src/ExistingSite/OctaneExistingSiteTestBase.php
+++ b/test/src/ExistingSite/OctaneExistingSiteTestBase.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Octane\Tests\ExistingSite;
+
+use weitzman\DrupalTestTraits\ExistingSiteBase;
+
+/**
+ * This class can be extended or modified for project-specific testing.
+ *
+ * Note that ExistingSite tests typically reside in the relevant custom modules:
+ *
+ * `src/modules/custom_module_core/tests/src/ExistingSite`
+ *
+ * This base class, and the other tests here are meant to be used as starting
+ * points and examples.
+ */
+abstract class OctaneExistingSiteTestBase extends ExistingSiteBase {
+
+
+}


### PR DESCRIPTION
This pulls in `weitzman/drupal-test-traits` and also adds an example test, plus an abstract base class that could be extended in projects, or just used as an example.

To run: `fin phpunit ./test`, or just `fin phpunit`.