### PR TITLE
Pass the user 1 password into "drush si" instead of setting afterwards

### DIFF
--- a/bin/init.sh
+++ b/bin/init.sh
@@ -41,14 +41,9 @@ COMPOSER_PROCESS_TIMEOUT=2000 COMPOSER_DISCARD_CHANGES=1 composer install
 if [ -e "src/config/default/system.site.yml" ]; then
   # If config exists, install using it.
   echo "Installing Drupal from existing config..."
-  drush si --db-url=$DB_URL --existing-config $CONFIRM
+  drush si --db-url=$DB_URL --account-pass="admin" --existing-config $CONFIRM
 else
   # Otherwise install clean from profile.
   echo "Installing Drupal profile: ${PROFILE}..."
-  drush si --db-url=$DB_URL ${PROFILE} $CONFIRM
+  drush si --db-url=$DB_URL --account-pass="admin" ${PROFILE} $CONFIRM
 fi
-
-# Manually set username and password for the admin user.
-# @see https://github.com/acquia/blt/issues/2984.
-drush sql:query "UPDATE users_field_data SET name = 'admin' WHERE uid = 1;"
-drush user:password admin "admin"


### PR DESCRIPTION
Setting afterwards was only necessary if running `blt setup` which doesn't support a custom username/password for user 1. But regular old `drush si` defaults to username of `admin` and supports `--account-pass` so we can just do it there.